### PR TITLE
👌 Allow path to config in build_all_assets

### DIFF
--- a/qt_dev_helper/config.py
+++ b/qt_dev_helper/config.py
@@ -10,6 +10,7 @@ from typing import Literal
 from typing import Optional
 from typing import Tuple
 from typing import TypedDict
+from typing import Union
 
 import tomli
 from pydantic import BaseSettings
@@ -369,13 +370,13 @@ def load_toml_config(path: Path) -> Config:
 
 
 def find_config(
-    start_path: Optional[Path] = None, config_file_name: str = "pyproject.toml"
+    start_path: Optional[Union[Path, str]] = None, config_file_name: str = "pyproject.toml"
 ) -> Path:
     """Find config file based on its name and start path, by traversing parent paths.
 
     Parameters
     ----------
-    start_path: Optional[Path]
+    start_path: Optional[Union[Path,str]]
         Path to start looking for the config file.
         Defaults to None which means the current dir will be used
     config_file_name: str
@@ -394,7 +395,7 @@ def find_config(
     if start_path is None:
         start_path = Path(os.curdir)
 
-    start_path = start_path.resolve()
+    start_path = Path(start_path).resolve()
 
     for path in (start_path, *start_path.parents):
         file_path = path / config_file_name
@@ -403,12 +404,12 @@ def find_config(
     raise ConfigNotFoundError(f"Could not find config file {config_file_name!r}.")
 
 
-def load_config(start_path: Optional[Path] = None) -> Config:
+def load_config(start_path: Optional[Union[Path, str]] = None) -> Config:
     """Load config from file.
 
     Parameters
     ----------
-    start_path: Optional[Path]
+    start_path: Optional[Union[Path,str]]
         Path to start looking for the config file.
         Defaults to None which means the current dir will be used
 

--- a/qt_dev_helper/config.py
+++ b/qt_dev_helper/config.py
@@ -396,6 +396,8 @@ def find_config(
         start_path = Path(os.curdir)
 
     start_path = Path(start_path).resolve()
+    if start_path.is_file():
+        start_path = start_path.parent
 
     for path in (start_path, *start_path.parents):
         file_path = path / config_file_name

--- a/qt_dev_helper/transpiler.py
+++ b/qt_dev_helper/transpiler.py
@@ -14,6 +14,7 @@ from qt_dev_helper.config import Config
 from qt_dev_helper.config import QtDevHelperConfigError
 from qt_dev_helper.config import RccKwargs
 from qt_dev_helper.config import UicKwargs
+from qt_dev_helper.config import load_config
 from qt_dev_helper.qt_tools import call_qt_tool
 from qt_dev_helper.utils import find_matching_files
 from qt_dev_helper.utils import format_rel_output_path
@@ -234,7 +235,7 @@ def build_resources(
 
 
 def build_all_assets(
-    config: Config,
+    config: Config | str | Path,
     log_function: Callable[..., None] = rich.print,
     recurse_folder: bool = True,
 ) -> list[Path]:
@@ -246,6 +247,7 @@ def build_all_assets(
     ----------
     config: Config
         Configuration to use for building assets.
+        If a path is passed it will try to find the config.
     log_function: Callable[..., None]
         Function used to print log messages. Defaults to rich.print
     recurse_folder: bool
@@ -255,7 +257,13 @@ def build_all_assets(
     -------
     list[Path]
         List of generated files.
+
+    See Also
+    --------
+    .load_config
     """
+    if not isinstance(config, Config):
+        config = load_config(config)
     built_files = []
     try:
         sass_file, qss_file = config.root_style_paths()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -238,10 +238,11 @@ def test_find_config_error(tmp_path: Path):
     assert str(exec_info.value) == "Could not find config file 'pyproject.toml'."
 
 
-def test_load_config(dummy_config: Config):
-    """On error parsing config."""
+@pytest.mark.parametrize("rel_path", ("", "assets/styles/theme.scss"))
+def test_load_config(dummy_config: Config, rel_path: str):
+    """Load config also works when path is a file which isn't the config file."""
 
-    result = load_config(dummy_config.base_path)
+    result = load_config(dummy_config.base_path / rel_path)
 
     assert result.dict() == dummy_config.dict()
 

--- a/tests/test_transpiler.py
+++ b/tests/test_transpiler.py
@@ -182,10 +182,13 @@ def test_build_resources(
     assert stdout == f"Creating: {expected_rel_out_path}\n\n"
 
 
-def test_build_all_assets_(dummy_config: Config, capsys: CaptureFixture):
+@pytest.mark.parametrize("use_path", (True, False))
+def test_build_all_assets_(dummy_config: Config, capsys: CaptureFixture, use_path: bool):
+    """Files are build when definitions are in the config."""
     dummy_config.uic_args = []
     dummy_config.rcc_args = []
-    result = build_all_assets(dummy_config)
+
+    result = build_all_assets(dummy_config.base_path if use_path is True else dummy_config)
 
     assert len(result) == 3
 
@@ -202,6 +205,7 @@ def test_build_all_assets_(dummy_config: Config, capsys: CaptureFixture):
 
 
 def test_build_all_assets_no_config(tmp_path: Path, capsys: CaptureFixture):
+    """No error if parts of the config are missing."""
     empty_config = Config(base_path=tmp_path)
     result = build_all_assets(empty_config)
 


### PR DESCRIPTION
This is useful for cases where `build_all_assets` is used in a `setup.py` since it allows building with only 2 lines of code.

```python
from qt_dev_helper.transpiler import build_all_assets

build_all_assets(__file__)
```

Note that the `pyproject.toml` needs to be bundled in the `sdist` and needs to contain a [PEP517](https://peps.python.org/pep-0517/) build instruction.

For example
```toml
[build-system]
requires = ["setuptools", "PySide6 >=2.2.3", "qt-dev-helper"]
build-backend = "setuptools.build_meta"
```