### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v5.0.0"
+    rev: "v6.0.0a1"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v6.0.0a1"
+    rev: "v6.0.0rc1"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,7 +91,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v6.0.0rc3"
+    rev: "v5.0.0"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,7 +62,7 @@ repos:
         additional_dependencies: [flake8-docstrings]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.950
+    rev: v0.960
     hooks:
       - id: mypy
         exclude: "docs"
@@ -91,7 +91,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/myint/rstcheck
-    rev: "v6.0.0rc1"
+    rev: "v6.0.0rc3"
     hooks:
       - id: rstcheck
         additional_dependencies: [sphinx]


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/qt-dev-helper/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-2.19.0-py2.py3-none-any.whl (199 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 199.3/199.3 kB 17.7 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.6.0-py2.py3-none-any.whl (21 kB)
Collecting pyyaml>=5.1
  Downloading PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (682 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 682.2/682.2 kB 50.8 MB/s eta 0:00:00
Collecting identify>=1.0.0
  Downloading identify-2.5.1-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.6/98.6 kB 16.3 MB/s eta 0:00:00
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.14.1-py2.py3-none-any.whl (8.8 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 8.8/8.8 MB 71.6 MB/s eta 0:00:00
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting six<2,>=1.9.0
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.4-py2.py3-none-any.whl (461 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 461.2/461.2 kB 58.2 MB/s eta 0:00:00
Collecting platformdirs<3,>=2
  Downloading platformdirs-2.5.2-py3-none-any.whl (14 kB)
Collecting filelock<4,>=3.2
  Downloading filelock-3.7.0-py3-none-any.whl (10 kB)
Installing collected packages: nodeenv, distlib, toml, six, pyyaml, platformdirs, identify, filelock, cfgv, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.4 filelock-3.7.0 identify-2.5.1 nodeenv-1.6.0 platformdirs-2.5.2 pre-commit-2.19.0 pyyaml-6.0 six-1.16.0 toml-0.10.2 virtualenv-20.14.1
```

### stderr:

```Shell
WARNING: There was an error checking the latest version of pip.
```

</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
Updating https://github.com/pre-commit/pre-commit-hooks ... [INFO] Initializing environment for https://github.com/pre-commit/pre-commit-hooks.
already up to date.
Updating https://github.com/asottile/pyupgrade ... [INFO] Initializing environment for https://github.com/asottile/pyupgrade.
already up to date.
Updating https://github.com/MarcoGorelli/absolufy-imports ... already up to date.
Updating https://github.com/PyCQA/isort ... already up to date.
Updating https://github.com/python/black ... [INFO] Initializing environment for https://github.com/python/black.
already up to date.
Updating https://github.com/pre-commit/mirrors-prettier ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
already up to date.
Updating https://github.com/pycqa/flake8 ... already up to date.
Updating https://github.com/asottile/yesqa ... already up to date.
Updating https://github.com/pre-commit/mirrors-mypy ... [INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
already up to date.
Updating https://github.com/PyCQA/pydocstyle ... already up to date.
Updating https://github.com/terrencepreilly/darglint ... already up to date.
Updating https://github.com/econchick/interrogate ... already up to date.
Updating https://github.com/myint/rstcheck ... [INFO] Initializing environment for https://github.com/myint/rstcheck.
updating v6.0.0a1 -> v6.0.0rc1.
Updating https://github.com/pre-commit/pygrep-hooks ... already up to date.
Updating https://github.com/codespell-project/codespell ... already up to date.
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@2.6.2.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:pydantic,types-all.
[INFO] Initializing environment for https://github.com/myint/rstcheck:sphinx.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/MarcoGorelli/absolufy-imports.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/terrencepreilly/darglint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
check builtin type constructor use.......................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
pyupgrade................................................................Passed
absolufy-imports.........................................................Passed
isort....................................................................Passed
black....................................................................Passed
prettier.................................................................Passed
flake8...................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
mypy.....................................................................Passed
pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Failed
- hook id: rstcheck
- exit code: 1

WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: api'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :recursive:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    qt_dev_helper'.
docs/api_docs.rst:7: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/api_docs.rst:7: (ERROR/3) Unknown directive type "autosummary".
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '  :toctree: {{ name }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '  :recursive:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '  {% for item in all_modules %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '  {%- endfor %}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: {{ name }}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    {% for item in all_attributes %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '        {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {%- endfor %}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: {{ name }}/functions'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :nosignatures:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    {% for item in all_functions %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '      {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {%- endfor %}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: {{ name }}/classes'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :nosignatures:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    {% for item in all_classes %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '      {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {%- endfor %}'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: 'Trying "autosummary" as canonical directive name.'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '.. autosummary::'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :toctree: {{ name }}/exceptions'.
WARNING:rstcheck.checker:Skipping unparsable message: '    :nosignatures:'.
WARNING:rstcheck.checker:Skipping unparsable message: ''.
WARNING:rstcheck.checker:Skipping unparsable message: '    {% for item in all_exceptions %}'.
WARNING:rstcheck.checker:Skipping unparsable message: '        {{ item }}'.
WARNING:rstcheck.checker:Skipping unparsable message: '    {%- endfor %}'.
docs/_templates/autosummary/module.rst:14: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:14: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:31: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:31: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:50: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:50: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:70: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:70: (ERROR/3) Unknown directive type "autosummary".
docs/_templates/autosummary/module.rst:91: (INFO/1) No directive entry for "autosummary" in module "docutils.parsers.rst.languages.en".
docs/_templates/autosummary/module.rst:91: (ERROR/3) Unknown directive type "autosummary".

rst ``code`` is two backticks............................................Passed
codespell................................................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)