### PR TITLE
🚀 Prepare release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,9 +103,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -U -r requirements_dev.txt
-          pip install -U .
+          python -m pip install --upgrade pip wheel setuptools
       - name: Build dist
         run: |
           python setup.py sdist bdist_wheel

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## 0.0.1 (2022-09-02)
+## 0.0.1 (2022-09-04)
 
 - First release on PyPI.

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,8 +7,8 @@ pydantic==1.9.2
 rich==12.5.1
 tomli==2.0.1
 typer==0.6.1
-qtsass==0.3.0 ;python_version < '3.10'
-qtsass@https://github.com/spyder-ide/qtsass/archive/refs/heads/master.zip ;python_version >= '3.10'
+qtsass>=0.3.0 ;python_version < '3.10'
+qtsass310>=0.3.1 ;python_version >= '3.10'
 
 # extra requirements
 PySide6==6.3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ install_requires =
     rich>=12.0.0
     tomli>=2.0.1
     qtsass>=0.3.0 ;python_version < '3.10'
-    qtsass@https://github.com/spyder-ide/qtsass/archive/refs/heads/master.zip ;python_version >= '3.10'
+    qtsass310>=0.3.1 ;python_version >= '3.10'
 python_requires = >=3.8
 include_package_data = True
 zip_safe = False


### PR DESCRIPTION
Updated release preparation [after releasing `qtsass310`](https://pypi.org/project/qtsass310/) as a workaround for missing python 3.10 support of `qtsass`.