### PR TITLE
👌 Use extend path when calling Qt tools

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.2 (2022-09-05)
+
+- 👌 Use extended path when calling Qt tools and add folder containing lib files (#52)
+
 ## 0.0.1 (2022-09-04)
 
-- First release on PyPI.
+- 🚀 First release on PyPI.

--- a/tests/test_qt_tools.py
+++ b/tests/test_qt_tools.py
@@ -31,7 +31,7 @@ def test_extend_qt_tool_path_missing_module(monkeypatch: MonkeyPatch):
 
         m.setattr(qt_tools, "package_path", mock_package_path)
 
-        assert extend_qt_tool_path.__wrapped__() == os.environ.get("path", "")
+        assert extend_qt_tool_path.__wrapped__() == os.environ.get("PATH", "")
 
 
 def test_find_qt_tool():


### PR DESCRIPTION
This is mainly an issue when using docker images (e.g. in the CI) where DLLs like `msvcp140_1.dll` are not on the path.
This then causes `uic` and `rcc` to crash since they cloud not find the DLLs.

For windows additional DLLs are shipped with `shiboken6`.

Missing `*.so` files (E.g. `libQt6Core.so.6`) might also cause problems on linux, so I preemptively added the lib folders.