### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
         additional_dependencies: [flake8-docstrings]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.3.0
+    rev: v1.4.0
     hooks:
       - id: mypy
         exclude: "docs"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.6.0
+    rev: v3.7.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
@@ -104,7 +104,7 @@ repos:
       - id: rst-backticks
 
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.2.5
     hooks:
       - id: codespell
         types: [file]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.4.0
+    rev: v3.6.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
@@ -57,7 +57,7 @@ repos:
       - id: flake8
 
   - repo: https://github.com/asottile/yesqa
-    rev: v1.4.0
+    rev: v1.5.0
     hooks:
       - id: yesqa
         additional_dependencies: [flake8-docstrings]


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/qt-dev-helper/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-3.3.2-py2.py3-none-any.whl (202 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 202.8/202.8 kB 4.2 MB/s eta 0:00:00
Collecting cfgv>=2.0.0 (from pre-commit)
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting identify>=1.0.0 (from pre-commit)
  Downloading identify-2.5.24-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.8/98.8 kB 7.1 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1 (from pre-commit)
  Downloading nodeenv-1.8.0-py2.py3-none-any.whl (22 kB)
Collecting pyyaml>=5.1 (from pre-commit)
  Downloading PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (701 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 701.2/701.2 kB 10.7 MB/s eta 0:00:00
Collecting virtualenv>=20.10.0 (from pre-commit)
  Downloading virtualenv-20.23.0-py3-none-any.whl (3.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 20.2 MB/s eta 0:00:00
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.8.16/x64/lib/python3.8/site-packages (from nodeenv>=0.11.1->pre-commit) (56.0.0)
Collecting distlib<1,>=0.3.6 (from virtualenv>=20.10.0->pre-commit)
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 kB 29.9 MB/s eta 0:00:00
Collecting filelock<4,>=3.11 (from virtualenv>=20.10.0->pre-commit)
  Downloading filelock-3.12.1-py3-none-any.whl (10 kB)
Collecting platformdirs<4,>=3.2 (from virtualenv>=20.10.0->pre-commit)
  Downloading platformdirs-3.5.3-py3-none-any.whl (15 kB)
Installing collected packages: distlib, pyyaml, platformdirs, nodeenv, identify, filelock, cfgv, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.12.1 identify-2.5.24 nodeenv-1.8.0 platformdirs-3.5.3 pre-commit-3.3.2 pyyaml-6.0 virtualenv-20.23.0
```

### stderr:

```Shell
[notice] A new release of pip is available: 22.0.4 -> 23.1.2
[notice] To update, run: pip install --upgrade pip
```

</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
[https://github.com/pre-commit/pre-commit-hooks] already up to date!
[https://github.com/asottile/pyupgrade] updating v3.4.0 -> v3.6.0
[https://github.com/MarcoGorelli/absolufy-imports] already up to date!
[https://github.com/PyCQA/isort] already up to date!
[https://github.com/python/black] already up to date!
[https://github.com/pre-commit/mirrors-prettier] already up to date!
[https://github.com/asottile/setup-cfg-fmt] already up to date!
[https://github.com/pycqa/flake8] already up to date!
[https://github.com/asottile/yesqa] updating v1.4.0 -> v1.5.0
[https://github.com/pre-commit/mirrors-mypy] already up to date!
[https://github.com/PyCQA/pydocstyle] already up to date!
[https://github.com/terrencepreilly/darglint] already up to date!
[https://github.com/econchick/interrogate] already up to date!
[https://github.com/myint/rstcheck] already up to date!
[https://github.com/pre-commit/pygrep-hooks] already up to date!
[https://github.com/codespell-project/codespell] already up to date!
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/asottile/pyupgrade.
[INFO] Initializing environment for https://github.com/python/black.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@3.0.0-alpha.9-for-vscode.
[INFO] Initializing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Initializing environment for https://github.com/asottile/yesqa.
[INFO] Initializing environment for https://github.com/asottile/yesqa:flake8-docstrings.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-all,pydantic.
[INFO] Initializing environment for https://github.com/myint/rstcheck.
[INFO] Initializing environment for https://github.com/myint/rstcheck:sphinx.
[INFO] Initializing environment for https://github.com/codespell-project/codespell.
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
check builtin type constructor use.......................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
pyupgrade................................................................Passed
absolufy-imports.........................................................Passed
isort....................................................................Passed
black....................................................................Passed
prettier.................................................................Passed
setup-cfg-fmt............................................................Passed
flake8...................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
mypy.....................................................................Passed
pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Passed
rst ``code`` is two backticks............................................Passed
codespell................................................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)