### PR TITLE
⬆️ UPGRADE: Autoupdate pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
         args: [--remove]
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.7.0
+    rev: v3.8.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
@@ -43,7 +43,7 @@ repos:
       - id: prettier
 
   - repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v2.3.0
+    rev: v2.4.0
     hooks:
       - id: setup-cfg-fmt
         args: [--include-version-classifiers]
@@ -63,7 +63,7 @@ repos:
         additional_dependencies: [flake8-docstrings]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.4.0
+    rev: v1.4.1
     hooks:
       - id: mypy
         exclude: "docs"


### PR DESCRIPTION
<!-- START pr-commits -->
<!-- END pr-commits -->

## Base PullRequest

default branch (https://github.com/s-weigand/qt-dev-helper/tree/main)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/build/src/bin
```



</details>
<details>
<summary><em>pip install pre-commit</em></summary>

```Shell
Collecting pre-commit
  Downloading pre_commit-3.3.3-py2.py3-none-any.whl (202 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 202.8/202.8 kB 3.7 MB/s eta 0:00:00
Collecting cfgv>=2.0.0 (from pre-commit)
  Downloading cfgv-3.3.1-py2.py3-none-any.whl (7.3 kB)
Collecting identify>=1.0.0 (from pre-commit)
  Downloading identify-2.5.24-py2.py3-none-any.whl (98 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 98.8/98.8 kB 26.1 MB/s eta 0:00:00
Collecting nodeenv>=0.11.1 (from pre-commit)
  Downloading nodeenv-1.8.0-py2.py3-none-any.whl (22 kB)
Collecting pyyaml>=5.1 (from pre-commit)
  Downloading PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl (701 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 701.2/701.2 kB 57.6 MB/s eta 0:00:00
Collecting virtualenv>=20.10.0 (from pre-commit)
  Downloading virtualenv-20.23.1-py3-none-any.whl (3.3 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 3.3/3.3 MB 86.7 MB/s eta 0:00:00
Requirement already satisfied: setuptools in /opt/hostedtoolcache/Python/3.8.17/x64/lib/python3.8/site-packages (from nodeenv>=0.11.1->pre-commit) (56.0.0)
Collecting distlib<1,>=0.3.6 (from virtualenv>=20.10.0->pre-commit)
  Downloading distlib-0.3.6-py2.py3-none-any.whl (468 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 468.5/468.5 kB 58.5 MB/s eta 0:00:00
Collecting filelock<4,>=3.12 (from virtualenv>=20.10.0->pre-commit)
  Downloading filelock-3.12.2-py3-none-any.whl (10 kB)
Collecting platformdirs<4,>=3.5.1 (from virtualenv>=20.10.0->pre-commit)
  Downloading platformdirs-3.8.0-py3-none-any.whl (16 kB)
Installing collected packages: distlib, pyyaml, platformdirs, nodeenv, identify, filelock, cfgv, virtualenv, pre-commit
Successfully installed cfgv-3.3.1 distlib-0.3.6 filelock-3.12.2 identify-2.5.24 nodeenv-1.8.0 platformdirs-3.8.0 pre-commit-3.3.3 pyyaml-6.0 virtualenv-20.23.1
```

### stderr:

```Shell
[notice] A new release of pip is available: 23.0.1 -> 23.1.2
[notice] To update, run: pip install --upgrade pip
```

</details>
<details>
<summary><em>pre-commit autoupdate || (exit 0);</em></summary>

```Shell
[https://github.com/pre-commit/pre-commit-hooks] already up to date!
[https://github.com/asottile/pyupgrade] updating v3.7.0 -> v3.8.0
[https://github.com/MarcoGorelli/absolufy-imports] already up to date!
[https://github.com/PyCQA/isort] already up to date!
[https://github.com/python/black] already up to date!
[https://github.com/pre-commit/mirrors-prettier] already up to date!
[https://github.com/asottile/setup-cfg-fmt] updating v2.3.0 -> v2.4.0
[https://github.com/pycqa/flake8] already up to date!
[https://github.com/asottile/yesqa] already up to date!
[https://github.com/pre-commit/mirrors-mypy] updating v1.4.0 -> v1.4.1
[https://github.com/PyCQA/pydocstyle] already up to date!
[https://github.com/terrencepreilly/darglint] already up to date!
[https://github.com/econchick/interrogate] already up to date!
[https://github.com/myint/rstcheck] already up to date!
[https://github.com/pre-commit/pygrep-hooks] already up to date!
[https://github.com/codespell-project/codespell] already up to date!
```



</details>
<details>
<summary><em>pre-commit run -a || (exit 0);</em></summary>

```Shell
[INFO] Initializing environment for https://github.com/asottile/pyupgrade.
[INFO] Initializing environment for https://github.com/python/black.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-prettier:prettier@3.0.0-alpha.9-for-vscode.
[INFO] Initializing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Initializing environment for https://github.com/asottile/yesqa.
[INFO] Initializing environment for https://github.com/asottile/yesqa:flake8-docstrings.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Initializing environment for https://github.com/pre-commit/mirrors-mypy:types-all,pydantic.
[INFO] Initializing environment for https://github.com/myint/rstcheck.
[INFO] Initializing environment for https://github.com/myint/rstcheck:sphinx.
[INFO] Initializing environment for https://github.com/codespell-project/codespell.
[INFO] Installing environment for https://github.com/pre-commit/pre-commit-hooks.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/pyupgrade.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/MarcoGorelli/absolufy-imports.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/isort.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/python/black.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-prettier.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/setup-cfg-fmt.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pycqa/flake8.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/asottile/yesqa.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/pre-commit/mirrors-mypy.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/PyCQA/pydocstyle.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/terrencepreilly/darglint.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/econchick/interrogate.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/myint/rstcheck.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
[INFO] Installing environment for https://github.com/codespell-project/codespell.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
check python ast.........................................................Passed
check builtin type constructor use.......................................Passed
fix end of files.........................................................Passed
trim trailing whitespace.................................................Passed
debug statements (python)................................................Passed
fix python encoding pragma...............................................Passed
pyupgrade................................................................Passed
absolufy-imports.........................................................Passed
isort....................................................................Passed
black....................................................................Passed
prettier.................................................................Passed
setup-cfg-fmt............................................................Passed
flake8...................................................................Passed
Strip unnecessary `# noqa`s..............................................Passed
mypy.....................................................................Failed
- hook id: mypy
- exit code: 1

qt_dev_helper/config.py:184: error: Unexpected keyword argument "extra" for "__init_subclass__" of "object"  [call-arg]
qt_dev_helper/config.py:184: error: Variable "pydantic.BaseSettings" is not valid as a type  [valid-type]
qt_dev_helper/config.py:184: note: See https://mypy.readthedocs.io/en/stable/common_issues.html#variables-vs-type-aliases
qt_dev_helper/config.py:184: error: Invalid base class "BaseSettings"  [misc]
qt_dev_helper/config.py:256: error: All overload variants of "root_validator" require at least one argument  [call-overload]
qt_dev_helper/config.py:256: note: Possible overload variants:
qt_dev_helper/config.py:256: note:     def root_validator(*, skip_on_failure: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
qt_dev_helper/config.py:256: note:     def root_validator(*, pre: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
qt_dev_helper/config.py:256: note:     def root_validator(*, pre: Literal[False], skip_on_failure: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
qt_dev_helper/config.py:261: error: All overload variants of "root_validator" require at least one argument  [call-overload]
qt_dev_helper/config.py:261: note: Possible overload variants:
qt_dev_helper/config.py:261: note:     def root_validator(*, skip_on_failure: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
qt_dev_helper/config.py:261: note:     def root_validator(*, pre: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
qt_dev_helper/config.py:261: note:     def root_validator(*, pre: Literal[False], skip_on_failure: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
qt_dev_helper/config.py:268: error: All overload variants of "root_validator" require at least one argument  [call-overload]
qt_dev_helper/config.py:268: note: Possible overload variants:
qt_dev_helper/config.py:268: note:     def root_validator(*, skip_on_failure: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
qt_dev_helper/config.py:268: note:     def root_validator(*, pre: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
qt_dev_helper/config.py:268: note:     def root_validator(*, pre: Literal[False], skip_on_failure: Literal[True], allow_reuse: bool = ...) -> Callable[[_V1RootValidatorFunctionType], _V1RootValidatorFunctionType]
/home/runner/.cache/pre-commit/reponqxurt1w/py_env-python3.8/lib/python3.8/site-packages/mypy/typeshed/stdlib/builtins.pyi:114: note: "__init_subclass__" of "object" defined here
tests/conftest.py:65: note: By default the bodies of untyped functions are not checked, consider using --check-untyped-defs  [annotation-unchecked]
Found 6 errors in 1 file (checked 27 source files)

pydocstyle...............................................................Passed
darglint.................................................................Passed
interrogate..............................................................Passed
rstcheck.................................................................Passed
rst ``code`` is two backticks............................................Passed
codespell................................................................Passed
```



</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- .pre-commit-config.yaml

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)