### PR TITLE
📦 Pin pydantic to version <2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
     hooks:
       - id: mypy
         exclude: "docs"
-        additional_dependencies: ["types-all", "pydantic"]
+        additional_dependencies: ["types-all", "pydantic<2"]
 
   ###################
   #   LINTER DOCS   #

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ project_urls =
 [options]
 packages = find:
 install_requires =
-    pydantic>=1.9.0
+    pydantic>=1.9.0,<2
     qtsass>=0.3.1
     rich>=12.0.0
     tomli>=2.0.1


### PR DESCRIPTION
With `pydantic>=2` the `BaseSettings` were moved out of `pydantic` into its own package `pydantic-settings`, thus we need to pin the version and make a new release in order to not break new installations.

See [CI error](https://github.com/s-weigand/qt-dev-helper/actions/runs/5440678702/jobs/9893843667) in the [upgrade PR](https://github.com/s-weigand/qt-dev-helper/pull/113)
```
Extension error:
Could not import extension sphinxcontrib.autodoc_pydantic (exception: `BaseSettings` has been moved to the `pydantic-settings` package. See https://docs.pydantic.dev/2.0/migration/#basesettings-has-moved-to-pydantic-settings for more details.
```