### PR TITLE
🚀 Prepare 0.0.4 release

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.0.4 (2023-07-08)
+
+- 📚🩹 Fix missing CLI docs on RTD by @s-weigand in (#63)
+- 🚇👌 Add py3.11 CI tests and ⬆️ autoupdate pre-commit config by @s-weigand in (#69)
+- 📚 Improve readme by @s-weigand in (#70)
+- 📦 Pin pydantic to version <2 by @s-weigand in (#115)
+
 ## 0.0.3 (2022-09-05)
 
 - 🗑️ Removed qtsass310 dependency in favor of qtsass>=0.3.1 (#54)

--- a/qt_dev_helper/__init__.py
+++ b/qt_dev_helper/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Sebastian Weigand"""
 __email__ = "s.weigand.phy@gmail.com"
-__version__ = "0.0.3"
+__version__ = "0.0.4"


### PR DESCRIPTION
Preparations for the 0.0.4 release.

- [🚧 Bumped version number from 0.0.3 to 0.0.4](https://github.com/s-weigand/qt-dev-helper/commit/0019135f7a90f6d16aef7c1790424b2ccb358f52)
- [🚧📚 Added changes to changelog](https://github.com/s-weigand/qt-dev-helper/commit/b74ff245a0b3a14c4d11361f10d2feefa4b6f262)