### PR TITLE
✨ Add official py313 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-12]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         # macOS-latest runs on M1 hardware, so we are using macos-12,
         # the last version supporting Intel hardware, to ensure compatibility.
         # exclude:

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+tests/data/outputs
 
 # Translations
 *.mo

--- a/README.md
+++ b/README.md
@@ -17,8 +17,20 @@ Toolbox to help develop Qt applications, improving the usability of the existing
 
 ## Installation
 
+To install the CLI you can run one of the following commands (assuming you use `pyside6` as Qt tooling suppliers):
+
 ```console
-pip install qt-dev-helper
+uv pip install "qt-dev-helper[cli,pyside6]"
+```
+
+> [!NOTE]
+> While it is also possible to install `qt-dev-helper` globally with `uv tool install "qt-dev-helper[cli,pyside6]"`
+> it is not recommend since it might cause version incompatibilities.
+
+OR
+
+```console
+pip install "qt-dev-helper[cli,pyside6]"
 ```
 
 OR
@@ -26,6 +38,11 @@ OR
 ```console
 conda install -c conda-forge qt-dev-helper
 ```
+
+> [!IMPORTANT]
+> If you do not have the `uic` and `rcc` executables on your `PATH`,
+> you still need to install the Qt tooling supplier with `pip` since there either is no conda version
+> or conda version comes without tools (e.g. `pyside6`)
 
 ## Features
 
@@ -44,7 +61,7 @@ conda install -c conda-forge qt-dev-helper
   - `PySide6-Essentials`
   - `qt6-applications`
   - `qt5-applications`
-- Ability to open all files in a folder in QtDesigner
+- Ability to open all `*.ui` files in a folder in QtDesigner
 
 ## Planned features
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ keywords = [ "qt_dev_helper" ]
 license = { file = "LICENSE" }
 
 authors = [ { name = "Sebastian Weigand", email = "s.weigand.phy@gmail.com" } ]
-requires-python = ">=3.9,<3.13"
+requires-python = ">=3.9"
 classifiers = [
   "Development Status :: 2 - Pre-Alpha",
   "Intended Audience :: Developers",
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 dynamic = [ "version" ]
 


### PR DESCRIPTION
This PR adds official python 3.13 support and updates the installation instructions in the readme.

## Summary by Sourcery

Add official support for Python 3.13 and update the CI configuration to test against this version. Revise the README to provide updated installation instructions, particularly for using PySide6 as a Qt tooling supplier.

New Features:
- Add official support for Python 3.13.

CI:
- Update CI configuration to include testing for Python 3.13.

Documentation:
- Update installation instructions in the README to include guidance on using PySide6 as a Qt tooling supplier.